### PR TITLE
feat: add translations for scorecard command 

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
         
           <tr>
             <td>commands.scorecard.desc</td>
-            <td>Display cwd or given repository OSSF Scorecard (Github only e.g fastify/fastify)</td>
+            <td>Display the OSSF Scorecard for a given repository or the current working directory (Github only, e.g. fastify/fastify)</td>
           </tr>
         
         </tbody>

--- a/index.html
+++ b/index.html
@@ -196,6 +196,11 @@
             <td>'{0}' has been selected as the new CLI language!</td>
           </tr>
         
+          <tr>
+            <td>commands.scorecard.desc</td>
+            <td>Display cwd or given repository OSSF Scorecard (Github only e.g fastify/fastify)</td>
+          </tr>
+        
         </tbody>
         <tbody class="fr">
           
@@ -337,6 +342,11 @@
             <tr>
               <td>commands.lang.new_selection</td>
               <td>'{0}' a été selectionné comme étant le nouveau langage du CLI !</td>
+            </tr>
+          
+            <tr>
+              <td>commands.scorecard.desc</td>
+              <td>Afficher la fiche de score OSSF du repo donné ou du repertoire actuel (Github uniquement ex. fastify/fastify)</td>
             </tr>
           
           </tbody>

--- a/languages/english.js
+++ b/languages/english.js
@@ -50,6 +50,9 @@ export const cli = {
       desc: "Configure the CLI default language",
       question_text: "What language do you want to use?",
       new_selection: tS`'${0}' has been selected as the new CLI language!`
+    },
+    scorecard: {
+      desc: "Display cwd or given repository OSSF Scorecard (Github only e.g fastify/fastify)"
     }
   }
 };

--- a/languages/english.js
+++ b/languages/english.js
@@ -52,7 +52,7 @@ export const cli = {
       new_selection: tS`'${0}' has been selected as the new CLI language!`
     },
     scorecard: {
-      desc: "Display cwd or given repository OSSF Scorecard (Github only e.g fastify/fastify)"
+      desc: "Display the OSSF Scorecard for a given repository or the current working directory (Github only, e.g. fastify/fastify)"
     }
   }
 };

--- a/languages/french.js
+++ b/languages/french.js
@@ -50,6 +50,9 @@ export const cli = {
       desc: "Configure le langage par défaut du CLI",
       question_text: "Quel langage souhaitez-vous utiliser ?",
       new_selection: tS`'${0}' a été selectionné comme étant le nouveau langage du CLI !`
+    },
+    scorecard: {
+      desc: "Afficher la fiche de score OSSF du repo donné ou du repertoire actuel (Github uniquement ex. fastify/fastify)"
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "type": "module",
   "dependencies": {
-    "cacache": "^17.0.4",
+    "cacache": "16.1.3",
     "lodash.get": "^4.4.2"
   }
 }


### PR DESCRIPTION
This PR add missing translations for https://github.com/NodeSecure/cli/issues/133.

Downgrade cacache from ^17.0.4 to 16.1.3 due to sync removals (see https://github.com/npm/cacache/releases/tag/v17.0.0).