### PR TITLE
docs: add banner i18n in readme and adapt badges in html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # NodeSecure i18n
-![version](https://img.shields.io/badge/dynamic/json.svg?style=for-the-badge&url=https://raw.githubusercontent.com/NodeSecure/i18n/master/package.json&query=$.version&label=Version)
-[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg?style=for-the-badge)](https://github.com/NodeSecure/i18n/graphs/commit-activity)
-[![OpenSSF
-Scorecard](https://api.securityscorecards.dev/projects/github.com/NodeSecure/i18n/badge?style=for-the-badge)](https://api.securityscorecards.dev/projects/github.com/NodeSecure/i18n)
-[![mit](https://img.shields.io/github/license/Naereen/StrapDown.js.svg?style=for-the-badge)](https://github.com/NodeSecure/i18n/blob/master/LICENSE)
-![build](https://img.shields.io/github/actions/workflow/status/NodeSecure/i18n/node.js.yml?style=for-the-badge)
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/4438263/226019205-7d86a8d5-345f-416f-bc8d-c4aef6f12868.jpg" alt="@nodesecure/i18n">
+</p>
+
+<p align="center">
+    <a href="https://github.com/NodeSecure/i18n">
+      <img src="https://img.shields.io/badge/dynamic/json.svg?style=for-the-badge&url=https://raw.githubusercontent.com/NodeSecure/i18n/master/package.json&query=$.version&label=Version" alt="npm version">
+    </a>
+    <a href="https://github.com/NodeSecure/i18n/graphs/commit-activity">
+      <img src="https://img.shields.io/badge/Maintained%3F-yes-green.svg?style=for-the-badge" alt="maintenance">
+    </a>
+    <a href="https://github.com/NodeSecure/i18n/blob/master/LICENSE">
+      <img src="https://img.shields.io/github/license/Naereen/StrapDown.js.svg?style=for-the-badge" alt="license">
+    </a>
+    <a href="https://api.securityscorecards.dev/projects/github.com/NodeSecure/i18n">
+      <img src="https://api.securityscorecards.dev/projects/github.com/NodeSecure/i18n/badge?style=for-the-badge" alt="OpenSSF Scorecard">
+    </a>
+      <img src="https://img.shields.io/github/actions/workflow/status/NodeSecure/i18n/node.js.yml?style=for-the-badge" alt="build">
+</p>
 
 Internationalization (**i18n**) utilities for NodeSecure tools like [CLI](https://github.com/NodeSecure/cli). 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# NodeSecure i18n
-
 <p align="center">
   <img src="https://user-images.githubusercontent.com/4438263/226019205-7d86a8d5-345f-416f-bc8d-c4aef6f12868.jpg" alt="@nodesecure/i18n">
 </p>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
       <img src="https://img.shields.io/badge/Maintained%3F-yes-green.svg?style=for-the-badge" alt="maintenance">
     </a>
     <a href="https://github.com/NodeSecure/i18n/blob/master/LICENSE">
-      <img src="https://img.shields.io/github/license/Naereen/StrapDown.js.svg?style=for-the-badge" alt="license">
+      <img src="https://img.shields.io/github/license/NodeSecure/i18n.svg?style=for-the-badge" alt="license">
     </a>
     <a href="https://api.securityscorecards.dev/projects/github.com/NodeSecure/i18n">
       <img src="https://api.securityscorecards.dev/projects/github.com/NodeSecure/i18n/badge?style=for-the-badge" alt="OpenSSF Scorecard">


### PR DESCRIPTION
I add the banner i18n in the readme as asked by @fraxken in this issue #67 

He said "like the RC readme" so, I adapt to the badges in html for deal with align center