### PR TITLE
feat(sast_warnings): add invalidSemVer translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -902,6 +902,11 @@
               <td>A Literal (string) contains an URL to a domain with a suspicious extension.</td>
             </tr>
           
+            <tr>
+              <td>invalidSemVer</td>
+              <td>Invalid semantic version</td>
+            </tr>
+          
           </tbody>
         <tbody class="fr">
           
@@ -965,6 +970,11 @@
             <tr>
               <td>shady_link</td>
               <td>Un Literal (string) contient une URL vers un domaine avec une extension suspecte.</td>
+            </tr>
+          
+            <tr>
+              <td>invalidSemVer</td>
+              <td>Version sémantique non valide</td>
             </tr>
           
           </tbody>

--- a/languages/english.js
+++ b/languages/english.js
@@ -117,7 +117,7 @@ const ui = {
 
 const warnings = {
   disable_scarf: "This dependency could collect data against your will so think to disable it with the env var: SCARF_ANALYTICS",
-  keylogging: "This dependency can retrieve your keyboard and mouse inputs. It can be used for 'keylogging' attacks/malwares.",
+  keylogging: "This dependency can retrieve your keyboard and mouse inputs. It can be used for 'keylogging' attacks/malwares."
 };
 
 const sast_warnings = {

--- a/languages/english.js
+++ b/languages/english.js
@@ -117,7 +117,7 @@ const ui = {
 
 const warnings = {
   disable_scarf: "This dependency could collect data against your will so think to disable it with the env var: SCARF_ANALYTICS",
-  keylogging: "This dependency can retrieve your keyboard and mouse inputs. It can be used for 'keylogging' attacks/malwares."
+  keylogging: "This dependency can retrieve your keyboard and mouse inputs. It can be used for 'keylogging' attacks/malwares.",
 };
 
 const sast_warnings = {
@@ -132,7 +132,8 @@ const sast_warnings = {
   suspicious_literal: "This mean that the sum of suspicious score of all Literals is bigger than 3.",
   obfuscated_code: "There's a very high probability that the code is obfuscated...",
   weak_crypto: "The code probably contains a weak crypto algorithm (md5, sha1...)",
-  shady_link: "A Literal (string) contains an URL to a domain with a suspicious extension."
+  shady_link: "A Literal (string) contains an URL to a domain with a suspicious extension.",
+  invalidSemVer: "Invalid semantic version"
 };
 
 export const english = { lang, cli, depWalker, ui, warnings, sast_warnings };

--- a/languages/french.js
+++ b/languages/french.js
@@ -134,7 +134,8 @@ const sast_warnings = {
   suspicious_file: "Un fichier suspect contenant plus de dix chaines de caractères encodés",
   obfuscated_code: "Il y a une très forte probabilité que le code soit obscurci...",
   weak_crypto: "Le code contient probablement un algorithme de chiffrement faiblement sécurisé (md5, sha1...).",
-  shady_link: "Un Literal (string) contient une URL vers un domaine avec une extension suspecte."
+  shady_link: "Un Literal (string) contient une URL vers un domaine avec une extension suspecte.",
+  invalidSemVer: "Version sémantique non valide"
 };
 
 export const french = { lang, cli, depWalker, ui, warnings, sast_warnings };


### PR DESCRIPTION
As part of PR 139 [https://github.com/NodeSecure/scanner/pull/139](url) it was necessary to create an invalidSemVer token for the French and English languages